### PR TITLE
Allow for spaces in the path to the key file.

### DIFF
--- a/ssh-key-add.cmd
+++ b/ssh-key-add.cmd
@@ -12,4 +12,4 @@ IF NOT EXIST "%KEY%" (
 	EXIT /B 1
 )
 
-docker run --rm -it --volume=%KEY%:/key --volumes-from=amazeeio-ssh-agent amazeeio/ssh-agent windows-key-add /key
+docker run --rm -it --volume="%KEY%":/key --volumes-from=amazeeio-ssh-agent amazeeio/ssh-agent windows-key-add /key


### PR DESCRIPTION
Some Windows Installations use the fully Username like "Daniel Schwiperich" instead the shortened one like "danie"

The current implementation will throw an error like

```
C:\Users\Daniel Schwiperich\Development\amazeeio\amazeeio-docker-windows>ssh-key-add.cmd "C:\Users\Daniel Schwiperich\.ssh\d.schwiperich"
docker: Error parsing reference: "Schwiperich\\.ssh\\d.schwiperich:/key" is not a valid repository/tag.
See 'docker run --help'.
```

Adding the quotes fixes this. 
